### PR TITLE
Support for hrefs that contain single quotes.

### DIFF
--- a/inc/mbMenu.js
+++ b/inc/mbMenu.js
@@ -419,8 +419,6 @@
             menuLine.find("a").css("cursor","pointer").click(function(){$.fn.removeMbMenu($.mbMenu.options.actualMenuOpener,true);})
           }
           menuLine.bind("click",function(event){
-            console.debug(event.type)
-
             if (($(voice).attr("action") || $(voice).attr("href")) && !isDisabled &&  !isBoxmenu && !isText){
               var target=$(voice).attr("target")?$(voice).attr("target"):"_self";
               if ($(voice).attr("href") && $(voice).attr("href").indexOf("javascript:")>-1){


### PR DESCRIPTION
I found a problem with links that contain a single quote.  Single quotes shouldn't need to be encoded in a URL's query string params.  This however causes problems in javascript.  

Any link containing a querystring param which includes a single quote will cause mbMenu to throw an error at line 429.  

I used escaped double quotes at line 427 to solve the issue.

Also removed call to console.debug.

Thanks.
