### PR TITLE
Generalized ajax dynamic menu creation.

### DIFF
--- a/inc/mbMenu.js
+++ b/inc/mbMenu.js
@@ -48,6 +48,17 @@
 			submenuLeft:4,
 			opacity:1,
 			ajaxAlwaysReload:false,
+			menuFetcher: function(op, m, callback){
+				$.ajax({
+					type: "POST",
+					url: op.options.template,
+					cache: false,
+					async: false,
+					data:"menuId="+m+(op.options.additionalData!=""?"&"+op.options.additionalData:""),
+					dataType:"html",
+					success: callback
+				});
+			},
 			openOnClick:true,
 			closeOnMouseOut:false,
 			closeAfter:500,
@@ -272,20 +283,11 @@
 				position:"absolute",
 				opacity:op.options.opacity
 			});
-			if (!$("#"+m).html() || op.ajaxAlwaysReload){
+			if (!$("#"+m).html() || op.options.ajaxAlwaysReload){
 				$("#"+m).remove();
-
-				$.ajax({
-					type: "POST",
-					url: op.options.template,
-					cache: false,
-					async: false,
-					data:"menuId="+m+(op.options.additionalData!=""?"&"+op.options.additionalData:""),
-					dataType:"html",
-					success: function(html){
-						$("body").append(html);
-						$("#"+m).hide();
-					}
+				op.options.menuFetcher(op, m, function(html){
+					$("body").append(html);
+					$("#"+m).hide();
 				});
 			}
 			$(this.menuContainer).attr("id", "mb_"+m).hide();


### PR DESCRIPTION
Generalized ajax behavior into a menu factory. This makes it possible
for the user to specify a function tht will create submenus (given the
'op' and menuName).

Add 'menuFetcher' to your options list and supply a function that takes
three parameters.

Here is the default version, which is just the current ajax fetch.

```
        menuFetcher: function(op, m, callback){
            $.ajax({
                type: "POST",
                url: op.options.template,
                cache: false,
                async: false,
                data:"menuId="+m+(op.options.additionalData!=""?"&"+op.options.additionalData:""),
                dataType:"html",
                success: callback
            });
        }

        I found this useful when mbmenu is used with angularjs,
        because often it is required to 'compile' some html into a
        menu.
```
