### PR TITLE
Generalize menu clone behavior.

### DIFF
--- a/inc/mbMenu.js
+++ b/inc/mbMenu.js
@@ -59,6 +59,9 @@
 					success: callback
 				});
 			},
+			cloner: function(op, m, source) {
+				return source.clone(true);
+			},
 			openOnClick:true,
 			closeOnMouseOut:false,
 			closeAfter:500,
@@ -296,12 +299,12 @@
 			var isBoxmenu=$("#"+m).hasClass("boxMenu");
 
 			if (isBoxmenu) {
-				this.voices = $("#"+m).clone(true);
+				this.voices = op.options.cloner(op, m, $("#"+m));
 				this.voices.css({display: "block"});
 				this.voices.attr("id", m+"_clone");
 			} else {
 				//TODO this will break <a rel=text> - if there are nested a's
-				this.voices= $("#"+m).find("a").clone(true);
+				this.voices= op.options.cloner(op, m, $("#"+m).find("a"));
 			}
 
 			/*


### PR DESCRIPTION
When a menu is to be created, it is cloned using jQuery.clone. This is problematic if the underlying objects have attached behavior (for instance, they are angularjs directives).

This modification adds a 'cloner' option which the caller can override and implement their specific behavior. The default is to invoke jQuery.clone as in the current implementation.
