### PR TITLE
Verification if there is space above the menu item selected

### DIFF
--- a/inc/mbMenu.js
+++ b/inc/mbMenu.js
@@ -527,8 +527,11 @@
 					}
 					break;
 			}
-			if ((actualY+mh)>= wh-10 && mh<wh){
-				t-=((actualY+mh)-wh)+10;
+			
+			if(op.options.openOnRight){
+				if ((actualY+mh)>= wh-10 && mh<wh){
+					t-=((actualY+mh)-wh)+10;
+				}
 			}
 
 			$(this.menu).css({


### PR DESCRIPTION
The verification if there is space above the menu item selected should be done only when the menu option openOnRight is true.
Before this change, the submenu is showed on top of the menu when there is space above the menu and this space can fit the submenu.
